### PR TITLE
数据帧头+长度支持断帧处理功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@
 /TestDemo/Client/obj
 /TestDemo/Server/bin
 /TestDemo/Server/obj
+/SerialPortTest/bin
+/SerialPortTest/obj

--- a/Communication.sln
+++ b/Communication.sln
@@ -61,6 +61,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "TestDemo\Client\C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "TestDemo\Server\Server.csproj", "{FBE42447-B0D2-499F-8451-790DEDC7ED28}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerialPortTest", "SerialPortTest\SerialPortTest.csproj", "{904DDB59-01A0-41A7-8311-D449764BA9EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +161,10 @@ Global
 		{FBE42447-B0D2-499F-8451-790DEDC7ED28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBE42447-B0D2-499F-8451-790DEDC7ED28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBE42447-B0D2-499F-8451-790DEDC7ED28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{904DDB59-01A0-41A7-8311-D449764BA9EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{904DDB59-01A0-41A7-8311-D449764BA9EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{904DDB59-01A0-41A7-8311-D449764BA9EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{904DDB59-01A0-41A7-8311-D449764BA9EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,6 +193,7 @@ Global
 		{36B514C9-DEA5-443E-95F0-BB8C2DFF6BCA} = {520BBC60-891F-49D7-B4E1-E462498DF89C}
 		{3A0E3C51-77EC-4935-8B49-7842216CAA5A} = {36B514C9-DEA5-443E-95F0-BB8C2DFF6BCA}
 		{FBE42447-B0D2-499F-8451-790DEDC7ED28} = {36B514C9-DEA5-443E-95F0-BB8C2DFF6BCA}
+		{904DDB59-01A0-41A7-8311-D449764BA9EC} = {520BBC60-891F-49D7-B4E1-E462498DF89C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4725AE6A-FFA2-4352-9DAB-5689B0B2C52F}

--- a/Parser/Parsers/HeadLengthParser.cs
+++ b/Parser/Parsers/HeadLengthParser.cs
@@ -21,9 +21,20 @@ namespace Parser.Parsers
         /// </summary>
         /// <param name="head">帧头</param>
         /// <param name="getDataLength">获取数据包长度</param>
+        /// <param name="processFrameBreak">
+        /// 是否断帧处理
+        /// <para>
+        /// <b>
+        /// 注意：<br/>
+        /// 若启用断帧处理功能则数据帧拆包速率会降低。<br/><br/>
+        /// 断帧数据示例（数据帧头为D4 F3 CC EC，2个字节的数据长度）：<br/>
+        /// D4 F3 CC EC D4 F3 CC EC 00 17 00 03 06 00 C2 00 02 00 04 66 66 02 41 BD C5 BB AA
+        /// </b>
+        /// </para>
+        /// </param>
         /// <param name="useChannel">是否启用内置处理队列</param>
         /// <exception cref="Exception"></exception>
-        public HeadLengthParser(byte[] head, GetDataLengthEventHandler getDataLength, bool useChannel = true) : base(useChannel)
+        public HeadLengthParser(byte[] head, GetDataLengthEventHandler getDataLength, bool useChannel = true, bool processFrameBreak = true) : base(useChannel, processFrameBreak)
         {
             if (head == null || head.Length == 0) throw new Exception("必须传入帧头");
             _head = head;
@@ -34,18 +45,29 @@ namespace Parser.Parsers
         /// 以特定字节数组为数据包头，数特定长度分包
         /// </summary>
         /// <param name="getDataLength">获取数据包长度</param>
+        /// <param name="processFrameBreak">
+        /// 是否断帧处理
+        /// <para>
+        /// <b>
+        /// 注意：<br/>
+        /// 若启用断帧处理功能则数据帧拆包速率会降低。<br/><br/>
+        /// 断帧数据示例（数据帧头为D4 F3 CC EC，2个字节的数据长度）：<br/>
+        /// D4 F3 CC EC D4 F3 CC EC 00 17 00 03 06 00 C2 00 02 00 04 66 66 02 41 BD C5 BB AA
+        /// </b>
+        /// </para>
+        /// </param>
         /// <param name="useChannel">是否启用内置处理队列</param>
         /// <exception cref="Exception"></exception>
-        public HeadLengthParser(GetDataLengthEventHandler getDataLength, bool useChannel = true) : base(useChannel)
+        public HeadLengthParser(GetDataLengthEventHandler getDataLength, bool useChannel = true, bool processFrameBreak = true) : base(useChannel, processFrameBreak)
         {
             _head = [];
             OnGetDataLength = getDataLength ?? throw new Exception("必须要getDataLength");
         }
 
         /// <inheritdoc/>
-        protected override async Task<bool> CanFindEndIndexAsync()
+        protected override async Task<FrameEndStatusCode> CanFindEndIndexAsync()
         {
-            if (_bytes.Count - (_startIndex - _bytes.StartIndex) < _bytes.GetCurrentMessageLength()) return false;
+            if (_bytes.Count - (_startIndex - _bytes.StartIndex) < _bytes.GetCurrentMessageLength()) return FrameEndStatusCode.Fail;
             if (_length == -1)
             {
                 byte[] temp = new byte[_bytes.Count - (_startIndex - _bytes.StartIndex)];
@@ -55,14 +77,14 @@ namespace Parser.Parsers
                     var rsp = await OnGetDataLength(temp);
                     if (rsp.StateCode != Parser.StateCode.Success)
                     {
-                        return false;
+                        return FrameEndStatusCode.Fail;
                     }
                     _length = rsp.Length;
                 }
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Get data length error");
-                    return false;
+                    return FrameEndStatusCode.Fail;
                 }
                 if (_length <= 0)
                     throw new Exception("数据长度必须大于0");
@@ -70,9 +92,52 @@ namespace Parser.Parsers
             if (_head.Length + _length > _bytes.Count - (_startIndex - _bytes.StartIndex))
             {
                 _bytes.SetCurrentMessageLength(_head.Length + _length);
-                return false;
+                return FrameEndStatusCode.Fail;
             }
-            return true;
+            return FrameEndStatusCode.Success;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<FrameEndStatusCode> CanFindEndIndexWithFrameBreakAsync()
+        {
+            try
+            {
+                byte[] temp = new byte[_bytes.Count - (_startIndex - _bytes.StartIndex)];
+                Array.Copy(_bytes.Bytes, _startIndex, temp, 0, temp.Length);
+
+                var rsp = await OnGetDataLength(temp);
+                if (rsp.StateCode != Parser.StateCode.Success)
+                {
+                    return FrameEndStatusCode.Fail;
+                }
+
+                var rspNext = FindIndex(_startIndex + _head.Length, _head);
+                if (rspNext.Code == Parser.Parsers.StateCode.Success)
+                {
+                    int dataLength = rspNext.Index - _startIndex;
+                    if (dataLength < rsp.Length)
+                    {
+                        _bytes.RemoveHeader(dataLength);
+                        return FrameEndStatusCode.ResearchHead;
+                    }
+
+                    _length = rsp.Length;
+                    return FrameEndStatusCode.Success;
+                }
+
+                if (_bytes.Count - (_startIndex - _bytes.StartIndex) >= rsp.Length)
+                {
+                    _length = rsp.Length;
+                    return FrameEndStatusCode.Success;
+                }
+
+                return FrameEndStatusCode.Fail;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Get data length error");
+                return FrameEndStatusCode.Fail;
+            }
         }
 
         /// <inheritdoc/>
@@ -108,13 +173,21 @@ namespace Parser.Parsers
         }
 
         /// <inheritdoc/>
+        protected override async Task ResetResearchHead()
+        {
+            _startIndex = -1;
+            _length = -1;
+            _bytes.SetCurrentMessageLength(-1);
+
+            await Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
         protected override async Task<bool> ReceiveOneFrameAsync()
         {
             if (await base.ReceiveOneFrameAsync())
             {
-                _startIndex = -1;
-                _length = -1;
-                _bytes.SetCurrentMessageLength(-1);
+                await ResetResearchHead();
                 return true;
             }
             return false;

--- a/SerialPortTest/PortTest.cs
+++ b/SerialPortTest/PortTest.cs
@@ -1,0 +1,95 @@
+﻿using Communication.Bus.PhysicalPort;
+using Parser;
+using Parser.Parsers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TopPortLib;
+using TopPortLib.Interfaces;
+
+namespace SerialPortTest
+{
+    public class PortTest
+    {
+        private ITopPort parsedPort;
+        private readonly byte[] Head = new byte[] { 0xD4, 0xF3, 0xCC, 0xEC };
+
+        public PortTest()
+        {
+            parsedPort = new TopPort(new SerialPort("COM38", 115200), new HeadLengthParser(Head, GetDataLength, processFrameBreak: true));
+            parsedPort.OnReceiveParsedData += ReceiverDataEventAsync;
+            parsedPort.OnConnect += ParsedPort_OnConnect;
+            parsedPort.OnDisconnect += ParsedPort_OnDisconnect;
+        }
+
+        private async Task<GetDataLengthRsp> GetDataLength(byte[] data)
+        {
+            int headCount = Head.Length;
+            int lengthCount = 2;
+
+            if (data.Length < headCount + lengthCount)
+            {
+                return new GetDataLengthRsp() { StateCode = Parser.StateCode.LengthNotEnough };
+            }
+
+            byte[] lengthArray = new byte[lengthCount];
+            Array.Copy(data, headCount, lengthArray, 0, lengthCount);
+            Array.Reverse(lengthArray);
+
+            int length = BitConverter.ToUInt16(lengthArray, 0);
+            length -= headCount;
+
+            return await Task.FromResult(new GetDataLengthRsp() { Length = length, StateCode = Parser.StateCode.Success });
+        }
+
+        public async Task Open()
+        {
+            try
+            {
+                await parsedPort.OpenAsync(false);
+            }
+            catch (Exception)
+            {
+                Trace.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}---->打开失败!!!!");
+            }
+        }
+
+        public async Task Close()
+        {
+            await parsedPort.CloseAsync();
+        }
+
+        private async Task ParsedPort_OnDisconnect()
+        {
+            Trace.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}---->断开连接");
+
+            await Task.CompletedTask;
+        }
+
+        private async Task ParsedPort_OnConnect()
+        {
+            Trace.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}---->连接设备");
+
+            await Task.CompletedTask;
+        }
+
+        private async Task ReceiverDataEventAsync(byte[] data)
+        {
+            if (data == null || data.Length <= 0)
+            {
+                return;
+            }
+
+            Trace.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}---->接收数据：{StringUtil.BytesToString(data)}");
+            await Task.CompletedTask;
+        }
+
+        public async Task SendAsync()
+        {
+            await parsedPort.SendAsync(new byte[] { 0xD4, 0xF3, 0xCC, 0xEC, 0x00, 0x17, 0x00, 0x03, 0x03, 0x01, 0x97, 0x00, 0x02, 0x00, 0x04, 0xE4, 0xE4, 0xE4, 0xE4, 0x3C, 0xD4, 0xBB, 0xAA });
+        }
+    }
+}

--- a/SerialPortTest/Program.cs
+++ b/SerialPortTest/Program.cs
@@ -1,0 +1,18 @@
+﻿namespace SerialPortTest
+{
+    internal class Program
+    {
+        static async Task Main(string[] args)
+        {
+            PortTest test = new PortTest();
+            await test.Open();
+
+            while (string.IsNullOrWhiteSpace(Console.ReadLine()))
+            {
+                await test.SendAsync();
+            }
+
+            Console.ReadLine();
+        }
+    }
+}

--- a/SerialPortTest/SerialPortTest.csproj
+++ b/SerialPortTest/SerialPortTest.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Communication\Communication.csproj" />
+    <ProjectReference Include="..\Crow\Crow.csproj" />
+    <ProjectReference Include="..\Parser\Parser.csproj" />
+    <ProjectReference Include="..\TopPortLib\TopPortLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SerialPortTest/StringUtil.cs
+++ b/SerialPortTest/StringUtil.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SerialPortTest
+{
+    public class StringUtil
+    {
+        public static string BytesToString(byte[] data)
+        {
+            return BytesToString(data, data.Length);
+        }
+
+        public static string BytesToString(byte[] data, int count)
+        {
+            if (data == null || data.Length == 0)
+            {
+                return string.Empty;
+            }
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < count; i++)
+            {
+                string s = ByteToString(data[i]);
+                sb.Append(s);
+                if (i != count - 1) sb.Append(" ");
+            }
+            return sb.ToString();
+        }
+
+        public static string ByteToString(byte value)
+        {
+            return value.ToString("X2");
+        }
+    }
+}


### PR DESCRIPTION
更新 `.gitignore` 文件以忽略构建输出，添加 `SerialPortTest` 项目到解决方案中。增强 `BaseParser` 和 `HeadLengthParser` 类以支持帧断处理。新增 `PortTest` 类用于串口通信，定义程序入口点的 `Program` 类，并提供字节数组转换工具的 `StringUtil` 类。更新项目文件以包含必要的依赖项。