### PR TITLE
包头+长度的数据帧解析器修复缓存器长度与数据帧长度比较判断数据帧完整接收切割异常问题。

### DIFF
--- a/Parser/Parsers/HeadLengthParser.cs
+++ b/Parser/Parsers/HeadLengthParser.cs
@@ -115,7 +115,7 @@ namespace Parser.Parsers
                 if (rspNext.Code == Parser.Parsers.StateCode.Success)
                 {
                     int dataLength = rspNext.Index - _startIndex;
-                    if (dataLength < rsp.Length)
+                    if (dataLength < _head.Length + rsp.Length)
                     {
                         _bytes.RemoveHeader(dataLength);
                         return FrameEndStatusCode.ResearchHead;
@@ -125,7 +125,7 @@ namespace Parser.Parsers
                     return FrameEndStatusCode.Success;
                 }
 
-                if (_bytes.Count - (_startIndex - _bytes.StartIndex) >= rsp.Length)
+                if (_bytes.Count - (_startIndex - _bytes.StartIndex) >= _head.Length + rsp.Length)
                 {
                     _length = rsp.Length;
                     return FrameEndStatusCode.Success;


### PR DESCRIPTION
包头+长度的数据帧解析器修复缓存器长度与数据帧长度比较判断数据帧完整接收切割异常问题。